### PR TITLE
Waffle chart label style

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -108,3 +108,6 @@
 .label.graphic {
 	background: hsla(0, 0%, 90%, 1);
 }
+.label.waffle_chart {
+	background: hsla(19, 100%, 94%, 1);
+}


### PR DESCRIPTION
Adds a colour background to the label so it doesn’t stand out from the
rest of the charts.

Thought we might want to add this style.