### PR TITLE
Adding sparkline_chart

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -111,3 +111,6 @@
 .label.waffle_chart {
 	background: hsla(19, 100%, 94%, 1);
 }
+.label.sparkline_chart {
+	background: hsla(54, 77%, 75%, 1);
+}

--- a/graphic-templates.json
+++ b/graphic-templates.json
@@ -39,6 +39,10 @@
 		{
 			"id": "waffle_chart",
 			"description": "Waffle chart"
+		},
+		{
+			"id": "sparkline_chart",
+			"description": "Sparkline chart"
 		}
 	],
 	"advanced": [


### PR DESCRIPTION
I believe this is all that's needed to get the new Sparkline Chart showing up in Chart Builder. We will have to wait until the Dailygraphics changes are approved and merged before this goes ahead.